### PR TITLE
fixed memory leaks

### DIFF
--- a/Asteroids/src/Application.cpp
+++ b/Asteroids/src/Application.cpp
@@ -553,6 +553,14 @@ Scene Application::GameplayScene() {
         if(player.AsteroidSpaceshipCollision(asteroids)) {
             // TODO: add a small wait so this sound effect can play
             sound_death.play();
+
+            // release memory allocated for asteroids before leaving
+            for(Asteroid* ast : asteroids) {
+                delete ast;
+            }
+            asteroids.clear();
+            
+            // change scene to game over
             return Scene::GAME_OVER_SCENE;
         }
         // score should show on top of everything so render last

--- a/Asteroids/src/Spaceship.cpp
+++ b/Asteroids/src/Spaceship.cpp
@@ -30,6 +30,15 @@ Spaceship::Spaceship()
     sound_fire.setBuffer(soundBuffer_fire);
 }
 
+Spaceship::~Spaceship() {
+    // release memory for manually allocated bullets
+    for(Bullet* b : m_bullets) {
+        delete b;
+    }
+    // clear bullets set
+    m_bullets.clear();
+}
+
 void Spaceship::SetVolumes(const float MASTER_VOLUME, const float SFX_VOLUME, const float MUSIC_VOLUME) {
     // set music and sfx volumes
     sound_fire.setVolume(100.0f * MASTER_VOLUME * SFX_VOLUME);

--- a/Asteroids/src/Spaceship.h
+++ b/Asteroids/src/Spaceship.h
@@ -42,7 +42,10 @@ class Spaceship : public Sprite {
     void Fire();
 
     public:
+    // constructor
     Spaceship();
+    // destructor
+    ~Spaceship();
 
     void AsteroidBulletCollision(const std::unordered_set<Asteroid*>& asteroids);
 


### PR DESCRIPTION
Fixed memory leaks caused by not releasing the memory allocated for bullets and asteroids.